### PR TITLE
RMHDR-263 Adding Three Week Sliding Window Timescale and SRI Sleep Measure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# RECOVER Sleep Measures
+
+## Purpose
+This repository hosts code to generate derived sleep measures on various timescales:
+- Daily
+- Weekly
+- Sliding 3 week window
+- All time
+- All time + N months post-infection
+
+## Usage
+
+The [config file](config.yml) contains the Synapse IDs and directory/file paths specifying where to fetch/write input and output data to, so please update the parameters in the config file as needed.
+
+Within the [scripts directory](scripts/), the [etl folder](scripts/etl/) contains ETL scripts which are run at the beginning of each main sleep measure script, and the [functions folder](scripts/functions/) contains custom R functions used in some of the main sleep measure scripts.
+
+For daily timescale summaries, run [daily-measures.R](scripts/daily-measures.R)
+- Generate summaries for derived sleep measures (as of Oct 2024, these are Sleep Start Time, Sleep End Time, Mid-sleep, Sleep Efficiency, Number of Awakenings, Number of Sleep Episodes, REM Sleep Fragmentation Index, and REM Onset Latency) on a daily timescale
+
+For all other timescales, run the following scripts individually to generate their outputs:
+- [percentSleepStartIn8pm2am.R](scripts/)
+- [sleepSD.R](scripts/sleepSD.R)
+- [sri.R](scripts/sri.R)
+- [timeInSleepStages.R](timeInSleepStages.R)
+
+All five of the main sleep measure scripts above is self-contained in that they each run the [fetch-data.R](scripts/etl/fetch-data.R) ETL script in the beginning and egress code (write data results to CSV and store in Synapse) at the end of their scripts.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,30 @@ The [config file](config.yml) contains the Synapse IDs and directory/file paths 
 Within the [scripts directory](scripts/), the [etl folder](scripts/etl/) contains ETL scripts which are run at the beginning of each main sleep measure script, and the [functions folder](scripts/functions/) contains custom R functions used in some of the main sleep measure scripts.
 
 For daily timescale summaries, run [daily-measures.R](scripts/daily-measures.R)
-- Generate summaries for derived sleep measures (as of Oct 2024, these are Sleep Start Time, Sleep End Time, Mid-sleep, Sleep Efficiency, Number of Awakenings, Number of Sleep Episodes, REM Sleep Fragmentation Index, and REM Onset Latency) on a daily timescale
+- Generates summaries for derived sleep measures on a daily timescale
+- As of Oct 2024, the daily sleep measures are:
+  - Sleep Start Time
+  - Sleep End Time
+  - Mid-sleep
+  - Sleep Efficiency
+  - Number of Awakenings
+  - Number of Sleep Episodes
+  - REM Sleep Fragmentation Index, and
+  - REM Onset Latency
+
+See [RMHDR-262](https://sagebionetworks.jira.com/browse/RMHDR-262) for further details
 
 For all other timescales, run the following scripts individually to generate their outputs:
 - [percentSleepStartIn8pm2am.R](scripts/)
-- [sleepSD.R](scripts/sleepSD.R)
-- [sri.R](scripts/sri.R)
+- [sleepSD.R](scripts/sleepSD.R)*
+  - See note below about infection dates data and Seven Bridges
+- [sri.R](scripts/sri.R)*
+  - See note below about infection dates data and Seven Bridges
 - [timeInSleepStages.R](timeInSleepStages.R)
 
+See [RMHDR-263](https://sagebionetworks.jira.com/browse/RMHDR-263) for further details
+
 All five of the main sleep measure scripts above is self-contained in that they each run the [fetch-data.R](scripts/etl/fetch-data.R) ETL script in the beginning and egress code (write data results to CSV and store in Synapse) at the end of their scripts.
+
+### Infection Dates Data and Seven Bridges
+Currently, the [sleepSD.R](scripts/sleepSD.R) and [sri.R](scripts/sri.R) scripts need to be run in the Seven Bridges compute environment, since this is currently the only location where the infection dates data can be accessed. In the beginning of both scripts, the user will be required to specify a path to the 'visits' CSV file, which contains data on infection dates.

--- a/config.yml
+++ b/config.yml
@@ -3,4 +3,7 @@ default:
   archiveVersion: main/archive/2024-06-13/
   selectedVarsFileID: syn53503994
   outputDataDir: ./temp-output-data
-  derivedMeasuresSynDirId: syn62668988
+  dailyMeasuresSynDirId: syn62668988
+  sleepSDSynDirId: syn62782378
+  timeInSleepStagesSynDirId: syn62782384
+  percentSleepStartSynDirId: syn62782401

--- a/config.yml
+++ b/config.yml
@@ -4,9 +4,11 @@ default:
   selectedVarsFileID: syn53503994
   outputDataDir: ./temp-output-data
   outputDataDirSleepSD: ./temp-output-data/sleepSD
+  outputDataDirSRI: ./temp-output-data/sri
   outputDataDirTimeInSleepStages: ./temp-output-data/timeInSleepStages
   outputDataDirPercentSleepStart: ./temp-output-data/percentSleepStart
   dailyMeasuresSynDirId: syn62668988
   sleepSDSynDirId: syn62782378
   timeInSleepStagesSynDirId: syn62782384
   percentSleepStartSynDirId: syn62782401
+  sriSynDirId: syn63389785

--- a/config.yml
+++ b/config.yml
@@ -3,4 +3,4 @@ default:
   archiveVersion: main/archive/2024-06-13/
   selectedVarsFileID: syn53503994
   outputDataDir: ./temp-output-data
-  dailyMeasuresSynDirID: syn62668988
+  derivedMeasuresSynDirId: syn62668988

--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,9 @@ default:
   archiveVersion: main/archive/2024-06-13/
   selectedVarsFileID: syn53503994
   outputDataDir: ./temp-output-data
+  outputDataDirSleepSD: ./temp-output-data/sleepSD
+  outputDataDirTimeInSleepStages: ./temp-output-data/timeInSleepStages
+  outputDataDirPercentSleepStart: ./temp-output-data/percentSleepStart
   dailyMeasuresSynDirId: syn62668988
   sleepSDSynDirId: syn62782378
   timeInSleepStagesSynDirId: syn62782384

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,5 @@
 default:
-  parquetDirID: syn61250818
+  parquetDirId: syn61250818
   archiveVersion: main/archive/2024-06-13/
   selectedVarsFileID: syn53503994
   outputDataDir: ./temp-output-data

--- a/scripts/daily-measures.R
+++ b/scripts/daily-measures.R
@@ -201,7 +201,7 @@ f <-
     synapser::File(
       path = str_subset(list.files(outputDataDir, full.names = T), 
                  "daily_sleep_measures.csv"),
-      parent = dailyMeasuresSynDirID
+      parent = derivedMeasuresSynDirId
     ), 
     executed = "https://github.com/Sage-Bionetworks/recover-sleep-measures/blob/main/scripts/daily-measures.R"
   )

--- a/scripts/daily-measures.R
+++ b/scripts/daily-measures.R
@@ -201,7 +201,7 @@ f <-
     synapser::File(
       path = str_subset(list.files(outputDataDir, full.names = T), 
                  "daily_sleep_measures.csv"),
-      parent = derivedMeasuresSynDirId
+      parent = dailyMeasuresSynDirId
     ), 
     executed = "https://github.com/Sage-Bionetworks/recover-sleep-measures/blob/main/scripts/daily-measures.R"
   )

--- a/scripts/daily-measures.R
+++ b/scripts/daily-measures.R
@@ -203,5 +203,6 @@ f <-
                  "daily_sleep_measures.csv"),
       parent = dailyMeasuresSynDirId
     ), 
-    executed = "https://github.com/Sage-Bionetworks/recover-sleep-measures/blob/main/scripts/daily-measures.R"
+    executed = "https://github.com/Sage-Bionetworks/recover-sleep-measures/blob/main/scripts/daily-measures.R",
+    used = parquetDirId
   )

--- a/scripts/etl/fetch-data.R
+++ b/scripts/etl/fetch-data.R
@@ -63,6 +63,10 @@ if (!dir.exists(outputDataDirSleepSD)) {
   dir.create(outputDataDirSleepSD)
 }
 
+if (!dir.exists(outputDataDirSRI)) {
+  dir.create(outputDataDirSRI)
+}
+
 if (!dir.exists(outputDataDirTimeInSleepStages)) {
   dir.create(outputDataDirTimeInSleepStages)
 }

--- a/scripts/etl/fetch-data.R
+++ b/scripts/etl/fetch-data.R
@@ -7,7 +7,7 @@ list2env(
 
 login <- synapser::synLogin()
 
-cat("Fetching data....\n")
+cat("Fetching data....")
 
 # Get input files from synapse
 selected_vars <- 
@@ -23,7 +23,7 @@ dataset_name_filter <-
 
 # Sync S3 bucket to local
 token <- synapser::synGetStsStorageToken(
-  entity = parquetDirID,
+  entity = parquetDirId,
   permission = "read_only",
   output_format = "json")
 
@@ -71,4 +71,4 @@ if (!dir.exists(outputDataDirPercentSleepStart)) {
   dir.create(outputDataDirPercentSleepStart)
 }
 
-cat("\nFetching data....OK\n")
+cat("OK\n")

--- a/scripts/etl/fetch-data.R
+++ b/scripts/etl/fetch-data.R
@@ -59,4 +59,16 @@ if (!dir.exists(outputDataDir)) {
   dir.create(outputDataDir)
 }
 
+if (!dir.exists(outputDataDirSleepSD)) {
+  dir.create(outputDataDirSleepSD)
+}
+
+if (!dir.exists(outputDataDirTimeInSleepStages)) {
+  dir.create(outputDataDirTimeInSleepStages)
+}
+
+if (!dir.exists(outputDataDirPercentSleepStart)) {
+  dir.create(outputDataDirPercentSleepStart)
+}
+
 cat("\nFetching data....OK\n")

--- a/scripts/functions/sri.R
+++ b/scripts/functions/sri.R
@@ -1,0 +1,17 @@
+#' SRI (Sleep Regularity Index)
+#'
+#' @param sleep_vec 
+#' @param epochs_per_day 
+#'
+#' @return
+#' @export
+#'
+#' @examples
+sri <- function(sleep_vec, epochs_per_day = 1440) {
+  
+  valid_epochs <- length(sleep_vec) - epochs_per_day
+  
+  sri <- 200 * mean(sleep_vec[1:valid_epochs] == sleep_vec[(epochs_per_day + 1):(epochs_per_day + valid_epochs)], na.rm = TRUE) - 100
+  
+  return(sri)
+}

--- a/scripts/functions/sri.R
+++ b/scripts/functions/sri.R
@@ -1,17 +1,180 @@
-#' SRI (Sleep Regularity Index)
-#'
-#' @param sleep_vec 
-#' @param epochs_per_day 
-#'
-#' @return
-#' @export
-#'
-#' @examples
-sri <- function(sleep_vec, epochs_per_day = 1440) {
+# Functions to calculate Sleep Regularity Index (SRI)
+# Based on implementation in github.com/mengelhard/sri
+
+calc_sri <- function(df, epochs_per_day = 2880) {
+  200 * mean(
+    df$SleepStatus[1:(nrow(df) - epochs_per_day)] == 
+      df$SleepStatus[(epochs_per_day + 1):nrow(df)]
+  ) - 100
+}
+
+# Parallel SRI calculation for a given dataset (optionally filter post-infection)
+calc_sri_parallel <- function(dataset_path, post_infection = FALSE) {
   
-  valid_epochs <- length(sleep_vec) - epochs_per_day
+  # Filter data post-infection if specified
+  if (post_infection) {
+    pre_df <- 
+      arrow::open_dataset(dataset_path) %>% 
+      collect() %>% 
+      filter(Date >= (first_infection_date + post_infection))
+  } else {
+    pre_df <-
+      arrow::open_dataset(dataset_path) %>% 
+      collect()
+  }
   
-  sri <- 200 * mean(sleep_vec[1:valid_epochs] == sleep_vec[(epochs_per_day + 1):(epochs_per_day + valid_epochs)], na.rm = TRUE) - 100
+  # Generate 30-second intervals for each sleep event
+  participant_df <- 
+    pre_df %>% 
+    arrange(StartDate) %>% 
+    rowwise() %>% 
+    reframe(
+      LogId = LogId,
+      id = id,
+      DateTime = seq(min(as_datetime(StartDate)), max(as_datetime(EndDate)), by = "30 sec"),
+      SleepStatus = SleepStatus
+    ) %>% 
+    group_by(DateTime) %>%
+    slice_tail(n = 1) %>%
+    ungroup()
   
-  return(sri)
+  # Get unique dates
+  unique_days <- 
+    participant_df %>%
+    mutate(Date = as.Date(DateTime)) %>% 
+    distinct(Date)
+  
+  # Generate a complete sequence of 30-second intervals for each day
+  full_intervals <- 
+    unique_days %>%
+    rowwise() %>%
+    mutate(DateTime = list(seq.POSIXt(as.POSIXct(paste0(Date, " 00:00:00")), 
+                                      as.POSIXct(paste0(Date, " 23:59:30")), 
+                                      by = "30 sec"))) %>%
+    unnest(cols = c(DateTime))
+  
+  # Merge the full sequence with the original data and fill missing SleepStatus values with NA
+  complete_df <- 
+    full_intervals %>%
+    left_join(participant_df, by = "DateTime") %>% 
+    mutate(SleepStatus = replace_na(SleepStatus, NA)) %>% 
+    mutate(SleepStatus = ifelse(is.na(id) & is.na(SleepStatus), 0, SleepStatus))
+  
+  # Calculate SRI
+  participant_sri <- calc_sri(complete_df, epochs_per_day = 2880)
+  
+  # Unscale SRI based on implementation in github.com/mengelhard/sri
+  unscaled_sri <- (sri + 100) / 200
+  
+  participant <- basename(dataset_path)
+  
+  return(data.frame("ParticipantIdentifier" = participant, sri = participant_sri, unscaled_sri = unscaled_sri))
+}
+
+# Function to calculate weekly SRI for each participant
+calc_weekly_sri <- function(df, epochs_per_day = 2880) {
+  
+  # Group data by week
+  df <- 
+    df %>%
+    mutate(Week = floor_date(DateTime, unit = "week"))
+  
+  # Calculate SRI for each week
+  weekly_sri <- 
+    df %>%
+    group_by(Week) %>%
+    summarise(
+      unscaled_sri = mean(SleepStatus[1:(n() - epochs_per_day)] == SleepStatus[(epochs_per_day + 1):n()]),
+      sri = 200 * unscaled_sri - 100,
+      .groups = "drop"
+    )
+  
+  return(weekly_sri)
+}
+
+# Function to calculate sliding window weekly SRI for each participant
+calc_weekly_sliding_sri <- function(df, epochs_per_day = 2880, window_size = 3, step_size = 1) {
+  
+  sliding_sri <- 
+    df %>% 
+    arrange(DateTime) %>% 
+    slider::slide_period(
+      .i = .$DateTime,
+      .period = "week",
+      .f = ~summarise(
+        .x, 
+        period_start = as.Date(first(floor_date(DateTime, "week"))),
+        period_end = as.Date(ceiling_date(last(floor_date(DateTime, "week")), "week")),
+        unscaled_sri = mean(SleepStatus[1:(n()-epochs_per_day)]==SleepStatus[(epochs_per_day+1):n()]),
+        sri = 200 * unscaled_sri - 100,
+        .groups = "drop"),
+      .every = step_size,
+      .before = window_size - 1,
+      .complete = FALSE) %>% 
+    bind_rows() %>% 
+    ungroup() %>% 
+    mutate(period_dt = as.numeric(period_end-period_start)) %>% 
+    filter(period_dt==21) %>% 
+    select(-period_dt)
+  
+  return(sliding_sri)
+}
+
+# Adjust calc_sri_parallel to calculate weekly SRI
+calc_sri_parallel_weekly <- function(dataset_path, sliding_window = FALSE, window_size = 3, step_size = 1) {
+  
+  # Generate 30-second intervals for each sleep event
+  participant_df <- 
+    arrow::open_dataset(dataset_path) %>% 
+    collect() %>% 
+    arrange(StartDate) %>% 
+    rowwise() %>% 
+    reframe(
+      LogId = LogId,
+      id = id,
+      DateTime = seq(min(as_datetime(StartDate)), max(as_datetime(EndDate)), by = "30 sec"),
+      SleepStatus = SleepStatus
+    ) %>% 
+    group_by(DateTime) %>%
+    slice_tail(n = 1) %>%
+    ungroup()
+  
+  # Get unique dates and generate full 30-second interval sequence for each day
+  unique_days <- 
+    participant_df %>%
+    mutate(Date = as.Date(DateTime)) %>% 
+    distinct(Date)
+  
+  full_intervals <- 
+    unique_days %>%
+    rowwise() %>%
+    mutate(DateTime = list(seq.POSIXt(as.POSIXct(paste0(Date, " 00:00:00")), 
+                                      as.POSIXct(paste0(Date, " 23:59:30")), 
+                                      by = "30 sec"))) %>%
+    unnest(cols = c(DateTime))
+  
+  # Merge with original data and fill missing SleepStatus
+  complete_df <- 
+    full_intervals %>%
+    left_join(participant_df, by = "DateTime") %>% 
+    mutate(SleepStatus = replace_na(SleepStatus, NA)) %>% 
+    mutate(SleepStatus = ifelse(is.na(id) & is.na(SleepStatus), 0, SleepStatus))
+  
+  # Calculate SRI for each week based on implementation in github.com/mengelhard/sri
+  if (sliding_window) {
+    result <- 
+      calc_weekly_sliding_sri(
+        complete_df, 
+        epochs_per_day = 2880, 
+        window_size = window_size, 
+        step_size = step_size
+      )
+  } else {
+    result <- 
+      calc_weekly_sri(complete_df, epochs_per_day = 2880)
+  }
+  
+  participant <- basename(dataset_path)
+  
+  return(bind_cols("ParticipantIdentifier" = participant, result))
 }

--- a/scripts/functions/sri.R
+++ b/scripts/functions/sri.R
@@ -64,11 +64,11 @@ calc_sri_parallel <- function(dataset_path, post_infection = FALSE) {
   participant_sri <- calc_sri(complete_df, epochs_per_day = 2880)
   
   # Unscale SRI based on implementation in github.com/mengelhard/sri
-  unscaled_sri <- (sri + 100) / 200
+  unscaled_sri <- (participant_sri + 100) / 200
   
   participant <- basename(dataset_path)
   
-  return(data.frame("ParticipantIdentifier" = participant, sri = participant_sri, unscaled_sri = unscaled_sri))
+  return(data.frame("ParticipantIdentifier" = participant, unscaled_sri = unscaled_sri, sri = participant_sri))
 }
 
 # Function to calculate weekly SRI for each participant
@@ -77,7 +77,7 @@ calc_weekly_sri <- function(df, epochs_per_day = 2880) {
   # Group data by week
   df <- 
     df %>%
-    mutate(Week = floor_date(DateTime, unit = "week"))
+    mutate(Week = as.Date(floor_date(DateTime, unit = "week")))
   
   # Calculate SRI for each week
   weekly_sri <- 

--- a/scripts/percentSleepStartIn8pm2am.R
+++ b/scripts/percentSleepStartIn8pm2am.R
@@ -88,7 +88,8 @@ thisScriptUrl <- "https://github.com/Sage-Bionetworks/recover-sleep-measures/blo
 
 manifest <-
   manifest %>%
-  mutate(executed = thisScriptUrl)
+  mutate(executed = thisScriptUrl,
+         used = parquetDirId)
 
 write_tsv(manifest, manifest_path)
 

--- a/scripts/percentSleepStartIn8pm2am.R
+++ b/scripts/percentSleepStartIn8pm2am.R
@@ -63,3 +63,38 @@ alltime_stats <-
     .groups = "drop"
   ) %>% 
   ungroup()
+
+write_csv(
+  x = weekly_stats, 
+  file = file.path(outputDataDirPercentSleepStart, "weekly_stats.csv")
+)
+
+write_csv(
+  x = alltime_stats, 
+  file = file.path(outputDataDirPercentSleepStart, "alltime_stats.csv")
+)
+
+manifest_path <- file.path(outputDataDirPercentSleepStart, "output-data-manifest.tsv")
+
+synapserutils::generate_sync_manifest(
+  directory_path = outputDataDirPercentSleepStart,
+  parent_id = percentSleepStartSynDirId,
+  manifest_path = manifest_path
+)
+
+manifest <- read_tsv(manifest_path)
+
+thisScriptUrl <- "https://github.com/Sage-Bionetworks/recover-sleep-measures/blob/main/scripts/percentSleepStartIn8pm2am.R"
+
+manifest <-
+  manifest %>%
+  mutate(executed = thisScriptUrl)
+
+write_tsv(manifest, manifest_path)
+
+synclient <- reticulate::import("synapseclient")
+syn_temp <- synclient$Synapse()
+syn_temp$login()
+
+synutils <- reticulate::import("synapseutils")
+synutils$syncToSynapse(syn = syn_temp, manifestFile = manifest_path)

--- a/scripts/sleepSD.R
+++ b/scripts/sleepSD.R
@@ -254,7 +254,7 @@ write_csv(
 
 synapserutils::generate_sync_manifest(
   directory_path = outputDataDirSleepSD,
-  parent_id = derivedMeasuresSynDirId,
+  parent_id = sleepSDSynDirId,
   manifest_path = "output-data-manifest.tsv"
 )
 

--- a/scripts/sleepSD.R
+++ b/scripts/sleepSD.R
@@ -145,3 +145,66 @@ alltime_stats <-
           ungroup()
       )
   )
+
+write_csv(
+  x = weekly_stats$midsleep$weekly, 
+  file = file.path(outputDataDir, "weekly_stats_midsleep.csv")
+)
+
+write_csv(
+  x = weekly_stats$duration$weekly, 
+  file = file.path(outputDataDir, "weekly_stats_duration.csv")
+)
+
+write_csv(
+  x = alltime_stats$midsleep$alltime, 
+  file = file.path(outputDataDir, "alltime_stats_midsleep.csv")
+)
+
+write_csv(
+  x = alltime_stats$midsleep$start3monthsPostInfection, 
+  file = file.path(outputDataDir, "alltime_stats_midsleep_3mo_post_infection.csv")
+)
+
+write_csv(
+  x = alltime_stats$midsleep$start6monthspostinfection, 
+  file = file.path(outputDataDir, "alltime_stats_midsleep_6mo_post_infection.csv")
+)
+
+write_csv(
+  x = alltime_stats$duration$alltime, 
+  file = file.path(outputDataDir, "alltime_stats_duration.csv")
+)
+
+write_csv(
+  x = alltime_stats$duration$start3monthspostinfection, 
+  file = file.path(outputDataDir, "alltime_stats_duration_3mo_post_infection.csv")
+)
+
+write_csv(
+  x = alltime_stats$duration$start6monthspostinfection, 
+  file = file.path(outputDataDir, "alltime_stats_duration_6mo_post_infection.csv")
+)
+
+synapserutils::generate_sync_manifest(
+  directory_path = outputDataDir,
+  parent_id = derivedMeasuresSynDirId,
+  manifest_path = "output-data-manifest.tsv"
+)
+
+manifest <- read_tsv("output-data-manifest.tsv")
+
+thisScriptUrl <- "https://github.com/Sage-Bionetworks/recover-sleep-measures/blob/main/scripts/sleepSD.R"
+
+manifest <-
+  manifest %>%
+  mutate(executed = thisScriptUrl)
+
+write_tsv(manifest, "output-data-manifest.tsv")
+
+synclient <- reticulate::import("synapseclient")
+syn_temp <- synclient$Synapse()
+syn_temp$login()
+
+synutils <- reticulate::import("synapseutils")
+synutils$syncToSynapse(syn = syn_temp, manifestFile = "output-data-manifest.tsv")

--- a/scripts/sleepSD.R
+++ b/scripts/sleepSD.R
@@ -252,13 +252,14 @@ write_csv(
   file = file.path(outputDataDirSleepSD, "alltime_stats_duration_6mo_post_infection.csv")
 )
 
+manifest_path <- file.path(outputDataDirSleepSD, "output-data-manifest.tsv")
+
 synapserutils::generate_sync_manifest(
   directory_path = outputDataDirSleepSD,
   parent_id = sleepSDSynDirId,
-  manifest_path = "output-data-manifest.tsv"
+  manifest_path = manifest_path
 )
 
-manifest_path <- file.path(outputDataDirSleepSD, "output-data-manifest.tsv")
 manifest <- read_tsv(manifest_path)
 
 thisScriptUrl <- "https://github.com/Sage-Bionetworks/recover-sleep-measures/blob/main/scripts/sleepSD.R"

--- a/scripts/sleepSD.R
+++ b/scripts/sleepSD.R
@@ -1,6 +1,6 @@
 source("scripts/etl/fetch-data.R")
 
-infections <- 
+infections <-
   read_csv(readline("Enter path to 'visits' csv file: ")) %>%
   filter(infect_yn_curr==1) %>%
   group_by(record_id) %>%

--- a/scripts/sleepSD.R
+++ b/scripts/sleepSD.R
@@ -1,7 +1,10 @@
 source("scripts/etl/fetch-data.R")
 
+# Load and filter infections data from the provided CSV file
+visits_file_path <- readline("Enter path to 'visits' csv file: ")
+
 infections <-
-  read_csv(readline("Enter path to 'visits' csv file: ")) %>% 
+  read_csv(visits_file_path) %>% 
   filter(infect_yn_curr==1) %>% 
   group_by(record_id) %>%
   summarise(
@@ -266,7 +269,8 @@ thisScriptUrl <- "https://github.com/Sage-Bionetworks/recover-sleep-measures/blo
 
 manifest <-
   manifest %>%
-  mutate(executed = thisScriptUrl)
+  mutate(executed = thisScriptUrl,
+         used = c(parquetDirId, visits_file_path))
 
 write_tsv(manifest, manifest_path)
 

--- a/scripts/sleepSD.R
+++ b/scripts/sleepSD.R
@@ -1,8 +1,8 @@
 source("scripts/etl/fetch-data.R")
 
 infections <-
-  read_csv(readline("Enter path to 'visits' csv file: ")) %>%
-  filter(infect_yn_curr==1) %>%
+  read_csv(readline("Enter path to 'visits' csv file: ")) %>% 
+  filter(infect_yn_curr==1) %>% 
   group_by(record_id) %>%
   summarise(
     first_infection_date = min(c(as_date(index_dt_curr), as_date(newinf_dt)), na.rm = TRUE),

--- a/scripts/sleepSD.R
+++ b/scripts/sleepSD.R
@@ -83,9 +83,9 @@ weekly_stats <-
                   select(-WeekStart) %>% 
                   distinct()
               }) %>% 
-              list_rbind()
+              bind_rows()
           }) %>% 
-          list_rbind() %>% 
+          bind_rows() %>% 
           ungroup() %>% 
           mutate(period_dt = as.numeric(period_end - period_start)) %>% 
           filter(period_dt==21)
@@ -124,9 +124,9 @@ weekly_stats <-
                   select(-WeekStart) %>% 
                   distinct()
               }) %>% 
-              list_rbind()
+              bind_rows()
           }) %>% 
-          list_rbind() %>% 
+          bind_rows() %>% 
           ungroup() %>% 
           mutate(period_dt = as.numeric(period_end - period_start)) %>% 
           filter(period_dt==21)

--- a/scripts/sri.R
+++ b/scripts/sri.R
@@ -99,6 +99,7 @@ tictoc::toc()
 
 # rm(merged_df)
 
+# Based on implementation in github.com/mengelhard/sri
 calc_sri <- function(df, epochs_per_day = 2880) {
   200 * mean(
     df$SleepStatus[1:(nrow(df) - epochs_per_day)] == 
@@ -155,6 +156,8 @@ calc_sri_parallel <- function(dataset_path, post_infection = FALSE) {
     mutate(SleepStatus = ifelse(is.na(id) & is.na(SleepStatus), 0, SleepStatus))
   
   sri <- calc_sri(complete_df, epochs_per_day = 2880)
+  
+  # Unscale based on implementation in github.com/mengelhard/sri
   unscaled_sri <- (sri + 100) / 200
   
   participant <- basename(dataset_path)

--- a/scripts/sri.R
+++ b/scripts/sri.R
@@ -1,0 +1,200 @@
+source("scripts/etl/fetch-data.R")
+
+fitbit_sleeplogs <- 
+  arrow::open_dataset(
+    s3$path(stringr::str_subset(dataset_paths, "sleeplogs$"))
+  )
+
+vars <- 
+  c("ParticipantIdentifier", 
+    "LogId",
+    "IsMainSleep",
+    "StartDate", # YYYY-MM-DDTHH:MM:SS format
+    "EndDate", # YYYY-MM-DDTHH:MM:SS format,
+    "SleepLevelDeep", 
+    "SleepLevelLight", 
+    "SleepLevelRem", 
+    "SleepLevelRestless", 
+    "MinutesAsleep")
+
+# Load desired subset of the data in memory and do some feature engineering
+sleeplogs_df <- 
+  fitbit_sleeplogs %>% 
+  select(all_of(c(vars))) %>% 
+  collect() %>% 
+  distinct() %>% 
+  mutate(
+    Date = lubridate::as_date(StartDate), # YYYY-MM-DD format
+    IsMainSleep = as.logical(IsMainSleep),
+    across(starts_with("SleepLevel"), as.numeric),
+    MinutesAsleep = as.numeric(MinutesAsleep),
+    SleepStartTime = lubridate::as_datetime(ifelse(IsMainSleep==TRUE, StartDate, NA)),
+    SleepStartTime = ((format(SleepStartTime, format = "%H:%M:%S") %>% lubridate::hms()) / lubridate::hours(24))*24,
+    SleepEndTime = lubridate::as_datetime(ifelse(IsMainSleep==TRUE, EndDate, NA)),
+    SleepEndTime = ((format(SleepEndTime, format = "%H:%M:%S") %>% lubridate::hms()) / lubridate::hours(24))*24,
+  )
+
+fitbit_sleeplogdetails <- 
+  arrow::open_dataset(
+    s3$path(stringr::str_subset(dataset_paths, "sleeplogdetails"))
+  )
+
+sleeplogdetails_vars <- 
+  selected_vars %>% 
+  filter(str_detect(Export, "sleeplogdetails$")) %>% 
+  pull(Variable)
+
+sleeplogdetails_df <- 
+  fitbit_sleeplogdetails %>% 
+  select(all_of(sleeplogdetails_vars)) %>% 
+  collect() %>% 
+  distinct() %>% 
+  left_join(y = (sleeplogs_df %>% select(ParticipantIdentifier, LogId, Date, IsMainSleep)), 
+            by = join_by("LogId", "ParticipantIdentifier")) %>% 
+  group_by(ParticipantIdentifier, LogId, id) %>% 
+  arrange(StartDate, .by_group = TRUE) %>% 
+  ungroup() %>% 
+  mutate(SleepStatus = ifelse(Value %in% c("wake", "awake"), 0, 1))
+
+sleeplogdetails_df_unique <- sleeplogdetails_df[!duplicated(sleeplogdetails_df),]
+
+tictoc::tic()
+ex_weekly <- 
+  lapply(unique(sleeplogdetails_df_unique$ParticipantIdentifier)[1], function(pid) {
+    df <- 
+      sleeplogdetails_df_unique %>% 
+      filter(ParticipantIdentifier==pid) %>%
+      select(ParticipantIdentifier, LogId, StartDate, EndDate, Value, Type) %>% 
+      mutate(StartDate = as_datetime(StartDate), EndDate = as_datetime(EndDate)) %>% 
+      filter(!is.na(StartDate), !is.na(EndDate)) %>% 
+      mutate(SleepStatus = ifelse(Value %in% c("wake", "awake"), 0, 1)) %>% 
+      rowwise() %>%
+      reframe(
+        ParticipantIdentifier = ParticipantIdentifier,
+        LogId = LogId,
+        DateTime = seq(StartDate, EndDate, by = "30 sec"),
+        Value = Value,
+        Type = Type,
+        SleepStatus = SleepStatus
+      ) %>%
+      ungroup() %>% 
+      group_by(ParticipantIdentifier, LogId) %>%
+      arrange(DateTime, .by_group = TRUE) %>% 
+      ungroup()
+    
+    lapply(unique(df$LogId), function(lid) {
+      df %>% 
+        filter(LogId==lid) %>% 
+        rowwise() %>% 
+        reframe(
+          ParticipantIdentifier = ParticipantIdentifier,
+          LogId = LogId,
+          DateTime = seq(floor_date(min(DateTime), "day"), ceiling_date(max(DateTime), "day"), by = "30 sec"),
+          Value = Value,
+          Type = Type,
+          SleepStatus = SleepStatus
+        )
+      }) %>% 
+      bind_rows()
+  }) %>% 
+  bind_rows()
+tictoc::toc()
+
+tictoc::tic()
+ex_sliding3weeks <- 
+  lapply(unique(sleeplogdetails_df_unique$ParticipantIdentifier)[0:5], function(pid) {
+    sleeplogdetails_df_unique %>% 
+      filter(ParticipantIdentifier==pid) %>%
+      select(ParticipantIdentifier, LogId, StartDate, EndDate, Value, Type) %>% 
+      mutate(StartDate = as_datetime(StartDate), EndDate = as_datetime(EndDate)) %>% 
+      filter(!is.na(StartDate), !is.na(EndDate)) %>% 
+      mutate(SleepStatus = ifelse(Value %in% c("wake", "awake"), 0, 1)) %>% 
+      rowwise() %>%
+      reframe(
+        ParticipantIdentifier = ParticipantIdentifier,
+        LogId = LogId,
+        DateTime = seq(StartDate, EndDate, by = "30 sec"),
+        Value = Value,
+        Type = Type,
+        SleepStatus = SleepStatus
+      ) %>%
+      ungroup() %>% 
+      group_by(ParticipantIdentifier, LogId) %>%
+      arrange(DateTime, .by_group = TRUE) %>% 
+      ungroup()
+  }) %>% 
+  bind_rows()
+tictoc::toc()
+
+tictoc::tic()
+ex_alltime <- 
+  lapply(unique(sleeplogdetails_df_unique$ParticipantIdentifier)[0:5], function(pid) {
+    sleeplogdetails_df_unique %>% 
+      filter(ParticipantIdentifier==pid) %>%
+      select(ParticipantIdentifier, LogId, StartDate, EndDate, Value, Type) %>% 
+      mutate(StartDate = as_datetime(StartDate), EndDate = as_datetime(EndDate)) %>% 
+      filter(!is.na(StartDate), !is.na(EndDate)) %>% 
+      mutate(SleepStatus = ifelse(Value %in% c("wake", "awake"), 0, 1)) %>% 
+      rowwise() %>%
+      reframe(
+        ParticipantIdentifier = ParticipantIdentifier,
+        LogId = LogId,
+        DateTime = seq(StartDate, EndDate, by = "30 sec"),
+        Value = Value,
+        Type = Type,
+        SleepStatus = SleepStatus
+      ) %>%
+      ungroup() %>% 
+      group_by(ParticipantIdentifier, LogId) %>%
+      arrange(DateTime, .by_group = TRUE) %>% 
+      ungroup()
+  }) %>% 
+  bind_rows()
+tictoc::toc()
+
+tictoc::tic()
+ex_alltime_post_infection <- 
+  lapply(unique(sleeplogdetails_df_unique$ParticipantIdentifier)[0:5], function(pid) {
+    sleeplogdetails_df_unique %>% 
+      filter(ParticipantIdentifier==pid) %>%
+      select(ParticipantIdentifier, LogId, StartDate, EndDate, Value, Type) %>% 
+      mutate(StartDate = as_datetime(StartDate), EndDate = as_datetime(EndDate)) %>% 
+      filter(!is.na(StartDate), !is.na(EndDate)) %>% 
+      mutate(SleepStatus = ifelse(Value %in% c("wake", "awake"), 0, 1)) %>% 
+      rowwise() %>%
+      reframe(
+        ParticipantIdentifier = ParticipantIdentifier,
+        LogId = LogId,
+        DateTime = seq(StartDate, EndDate, by = "30 sec"),
+        Value = Value,
+        Type = Type,
+        SleepStatus = SleepStatus
+      ) %>%
+      ungroup() %>% 
+      group_by(ParticipantIdentifier, LogId) %>%
+      arrange(DateTime, .by_group = TRUE) %>% 
+      ungroup()
+  }) %>% 
+  bind_rows()
+tictoc::toc()
+
+# Assuming sleeplogs_df has a column 'SleepStatus' (1 = sleep, 0 = wake)
+# Group data by ParticipantIdentifier and calculate SRI
+sri_results <- 
+  sleeplogdetails_df_unique %>%
+  arrange(ParticipantIdentifier, Date, SleepStartTime) %>%  # Ensure the data is sorted correctly
+  group_by(ParticipantIdentifier) %>%
+  summarise(
+    SRI = sri(SleepStatus, epochs_per_day = 2880)
+  )
+
+# Weekly statistics
+weekly_stats <- 
+  list(
+    weekly = NULL,
+    sliding3weeks = NULL
+  )
+
+# All-time statistics
+alltime_stats
+

--- a/scripts/sri.R
+++ b/scripts/sri.R
@@ -120,27 +120,41 @@ dataset_paths_first_half <- dataset_paths[1:half_size]
 dataset_paths_second_half <- dataset_paths[(half_size + 1):length(dataset_paths)]
 
 # All-time timescale summarization
-
 # Run the first half of the datasets in parallel
 tictoc::tic()
-results_first_half <- future_lapply(dataset_paths_first_half, calc_sri_parallel) %>% bind_rows()
+results_first_half <- 
+  future_lapply(
+    dataset_paths_first_half, 
+    calc_sri_parallel) %>% 
+  bind_rows()
 tictoc::toc()
 
 # Run the second half of the datasets in parallel
 tictoc::tic()
-results_second_half <- future_lapply(dataset_paths_second_half, calc_sri_parallel) %>% bind_rows()
+results_second_half <- 
+  future_lapply(
+    dataset_paths_second_half, 
+    calc_sri_parallel) %>% 
+  bind_rows()
 tictoc::toc()
 
 # Combine the results from both halves
-final_results <- bind_rows(results_first_half, results_second_half)
+final_results <- 
+  bind_rows(results_first_half, results_second_half)
 
 # All-time 3 months post-infection results
 results_first_half_post_infection_3 <- 
-  future_lapply(dataset_paths_first_half, calc_sri_parallel, months(3)) %>% 
+  future_lapply(
+    dataset_paths_first_half, 
+    calc_sri_parallel, 
+    months(3)) %>% 
   bind_rows()
 
 results_second_half_post_infection_3 <- 
-  future_lapply(dataset_paths_second_half, calc_sri_parallel, months(3)) %>% 
+  future_lapply(
+    dataset_paths_second_half, 
+    calc_sri_parallel, 
+    months(3)) %>% 
   bind_rows()
 
 final_results_post_infection_3 <- 
@@ -148,7 +162,10 @@ final_results_post_infection_3 <-
 
 # All-time 6 months post-infection results
 results_first_half_post_infection_6 <- 
-  future_lapply(dataset_paths_first_half, calc_sri_parallel, months(6)) %>% 
+  future_lapply(
+    dataset_paths_first_half, 
+    calc_sri_parallel, 
+    months(6)) %>% 
   bind_rows()
 
 results_second_half_post_infection_6 <- 
@@ -175,7 +192,8 @@ weekly_results_second_half <-
   bind_rows()
 tictoc::toc()
 
-weekly_results <- bind_rows(weekly_results_first_half, weekly_results_second_half)
+weekly_results <- 
+  bind_rows(weekly_results_first_half, weekly_results_second_half)
 
 # Weekly sliding window timescale summarization
 tictoc::tic()
@@ -200,7 +218,8 @@ weekly_sliding_results_second_half <-
   bind_rows()
 tictoc::toc()
 
-weekly_sliding_results <- bind_rows(weekly_results_first_half, weekly_results_second_half)
+weekly_sliding_results <- 
+  bind_rows(weekly_results_first_half, weekly_results_second_half)
 
 # Weekly timescale results
 weekly_stats <- 

--- a/scripts/sri.R
+++ b/scripts/sri.R
@@ -8,8 +8,10 @@ num_cores <- floor(parallel::detectCores()*0.75)
 plan(multisession, workers = num_cores)
 
 # Load and filter infections data from the provided CSV file
+visits_file_path <- readline("Enter path to 'visits' csv file: ")
+
 infections <-
-  read_csv(readline("Enter path to 'visits' csv file: ")) %>% 
+  read_csv(visits_file_path) %>% 
   filter(infect_yn_curr==1) %>% 
   group_by(record_id) %>%
   summarise(
@@ -277,7 +279,8 @@ thisScriptUrl <- "https://github.com/Sage-Bionetworks/recover-sleep-measures/blo
 
 manifest <-
   manifest %>%
-  mutate(executed = thisScriptUrl)
+  mutate(executed = thisScriptUrl,
+         used = c(parquetDirId, visits_file_path))
 
 write_tsv(manifest, manifest_path)
 

--- a/scripts/sri.R
+++ b/scripts/sri.R
@@ -1,4 +1,5 @@
 source("scripts/etl/fetch-data.R")
+source("scripts/functions/sri.R")
 
 library(future.apply)
 
@@ -110,78 +111,6 @@ tictoc::toc()
 
 # rm(merged_df)
 
-# Function to calculate Sleep Regularity Index (SRI)
-# Based on implementation in github.com/mengelhard/sri
-calc_sri <- function(df, epochs_per_day = 2880) {
-  200 * mean(
-    df$SleepStatus[1:(nrow(df) - epochs_per_day)] == 
-      df$SleepStatus[(epochs_per_day + 1):nrow(df)]
-  ) - 100
-}
-
-# Parallel SRI calculation for a given dataset (optionally filter post-infection)
-calc_sri_parallel <- function(dataset_path, post_infection = FALSE) {
-  
-  # Filter data post-infection if specified
-  if (post_infection) {
-    pre_df <- 
-      arrow::open_dataset(dataset_path) %>% 
-      collect() %>% 
-      filter(Date >= (first_infection_date + post_infection))
-  } else {
-    pre_df <-
-      arrow::open_dataset(dataset_path) %>% 
-      collect()
-  }
-  
-  # Generate 30-second intervals for each sleep event
-  participant_df <- 
-    pre_df %>% 
-    arrange(StartDate) %>% 
-    rowwise() %>% 
-    reframe(
-      LogId = LogId,
-      id = id,
-      DateTime = seq(min(as_datetime(StartDate)), max(as_datetime(EndDate)), by = "30 sec"),
-      SleepStatus = SleepStatus
-    ) %>% 
-    group_by(DateTime) %>%
-    slice_tail(n = 1) %>%
-    ungroup()
-  
-  # Get unique dates
-  unique_days <- 
-    participant_df %>%
-    mutate(Date = as.Date(DateTime)) %>% 
-    distinct(Date)
-  
-  # Generate a complete sequence of 30-second intervals for each day
-  full_intervals <- 
-    unique_days %>%
-    rowwise() %>%
-    mutate(DateTime = list(seq.POSIXt(as.POSIXct(paste0(Date, " 00:00:00")), 
-                                      as.POSIXct(paste0(Date, " 23:59:30")), 
-                                      by = "30 sec"))) %>%
-    unnest(cols = c(DateTime))
-  
-  # Merge the full sequence with the original data and fill missing SleepStatus values with NA
-  complete_df <- 
-    full_intervals %>%
-    left_join(participant_df, by = "DateTime") %>% 
-    mutate(SleepStatus = replace_na(SleepStatus, NA)) %>% 
-    mutate(SleepStatus = ifelse(is.na(id) & is.na(SleepStatus), 0, SleepStatus))
-  
-  # Calculate SRI
-  participant_sri <- calc_sri(complete_df, epochs_per_day = 2880)
-  
-  # Unscale SRI based on implementation in github.com/mengelhard/sri
-  unscaled_sri <- (sri + 100) / 200
-  
-  participant <- basename(dataset_path)
-  
-  return(data.frame("ParticipantIdentifier" = participant, sri = participant_sri, unscaled_sri = unscaled_sri))
-}
-
 # Split dataset_paths into two halves for processing
 dataset_paths <- list.dirs(merged_df_path)
 dataset_paths <- dataset_paths[dataset_paths != merged_df_path]
@@ -190,13 +119,15 @@ half_size <- ceiling(length(dataset_paths) / 2)
 dataset_paths_first_half <- dataset_paths[1:half_size]
 dataset_paths_second_half <- dataset_paths[(half_size + 1):length(dataset_paths)]
 
+# All-time timescale summarization
+
 # Run the first half of the datasets in parallel
-tictoc::tic("SRI calculation for first half")
+tictoc::tic()
 results_first_half <- future_lapply(dataset_paths_first_half, calc_sri_parallel) %>% bind_rows()
 tictoc::toc()
 
 # Run the second half of the datasets in parallel
-tictoc::tic("SRI calculation for second half")
+tictoc::tic()
 results_second_half <- future_lapply(dataset_paths_second_half, calc_sri_parallel) %>% bind_rows()
 tictoc::toc()
 
@@ -227,117 +158,8 @@ results_second_half_post_infection_6 <-
 final_results_post_infection_6 <- 
   bind_rows(results_first_half_post_infection_6, results_second_half_post_infection_6)
 
-
-# Function to calculate weekly SRI for each participant
-calc_weekly_sri <- function(df, epochs_per_day = 2880) {
-  
-  # Group data by week
-  df <- 
-    df %>%
-    mutate(Week = floor_date(DateTime, unit = "week"))
-  
-  # Calculate SRI for each week
-  weekly_sri <- 
-    df %>%
-    group_by(Week) %>%
-    summarise(
-      unscaled_sri = mean(SleepStatus[1:(n() - epochs_per_day)] == SleepStatus[(epochs_per_day + 1):n()]),
-      sri = 200 * unscaled_sri - 100,
-      .groups = "drop"
-    )
-  
-  return(weekly_sri)
-}
-
-# Function to calculate sliding window weekly SRI for each participant
-calc_weekly_sliding_sri <- function(df, epochs_per_day = 2880, window_size = 3, step_size = 1) {
-  
-  sliding_sri <- 
-    df %>% 
-    arrange(DateTime) %>% 
-    slider::slide_period(
-      .i = .$DateTime,
-      .period = "week",
-      .f = ~summarise(
-        .x, 
-        period_start = as.Date(first(floor_date(DateTime, "week"))),
-        period_end = as.Date(ceiling_date(last(floor_date(DateTime, "week")), "week")),
-        unscaled_sri = mean(SleepStatus[1:(n()-epochs_per_day)]==SleepStatus[(epochs_per_day+1):n()]),
-        sri = 200 * unscaled_sri - 100,
-        .groups = "drop"),
-      .every = step_size,
-      .before = window_size - 1,
-      .complete = FALSE) %>% 
-    bind_rows() %>% 
-    ungroup() %>% 
-    mutate(period_dt = as.numeric(period_end-period_start)) %>% 
-    filter(period_dt==21) %>% 
-    select(-period_dt)
-  
-  return(sliding_sri)
-}
-
-# Adjust calc_sri_parallel to calculate weekly SRI
-calc_sri_parallel_weekly <- function(dataset_path, sliding_window = FALSE, window_size = 3, step_size = 1) {
-  
-  # Generate 30-second intervals for each sleep event
-  participant_df <- 
-    arrow::open_dataset(dataset_path) %>% 
-    collect() %>% 
-    arrange(StartDate) %>% 
-    rowwise() %>% 
-    reframe(
-      LogId = LogId,
-      id = id,
-      DateTime = seq(min(as_datetime(StartDate)), max(as_datetime(EndDate)), by = "30 sec"),
-      SleepStatus = SleepStatus
-    ) %>% 
-    group_by(DateTime) %>%
-    slice_tail(n = 1) %>%
-    ungroup()
-  
-  # Get unique dates and generate full 30-second interval sequence for each day
-  unique_days <- 
-    participant_df %>%
-    mutate(Date = as.Date(DateTime)) %>% 
-    distinct(Date)
-  
-  full_intervals <- 
-    unique_days %>%
-    rowwise() %>%
-    mutate(DateTime = list(seq.POSIXt(as.POSIXct(paste0(Date, " 00:00:00")), 
-                                      as.POSIXct(paste0(Date, " 23:59:30")), 
-                                      by = "30 sec"))) %>%
-    unnest(cols = c(DateTime))
-  
-  # Merge with original data and fill missing SleepStatus
-  complete_df <- 
-    full_intervals %>%
-    left_join(participant_df, by = "DateTime") %>% 
-    mutate(SleepStatus = replace_na(SleepStatus, NA)) %>% 
-    mutate(SleepStatus = ifelse(is.na(id) & is.na(SleepStatus), 0, SleepStatus))
-  
-  # Calculate SRI for each week based on implementation in github.com/mengelhard/sri
-  if (sliding_window) {
-    result <- 
-      calc_weekly_sliding_sri(
-        complete_df, 
-        epochs_per_day = 2880, 
-        window_size = window_size, 
-        step_size = step_size
-      )
-  } else {
-    result <- 
-      calc_weekly_sri(complete_df, epochs_per_day = 2880)
-  }
-  
-  participant <- basename(dataset_path)
-  
-  return(bind_cols("ParticipantIdentifier" = participant, result))
-}
-
-# Run the first half of the datasets in parallel for weekly SRI
-tictoc::tic("Weekly SRI calculation for first half")
+# Weekly timescale summarization
+tictoc::tic()
 weekly_results_first_half <- 
   future_lapply(
     dataset_paths_first_half, 
@@ -345,8 +167,7 @@ weekly_results_first_half <-
   bind_rows()
 tictoc::toc()
 
-# Run the second half of the datasets in parallel for weekly SRI
-tictoc::tic("Weekly SRI calculation for second half")
+tictoc::tic()
 weekly_results_second_half <- 
   future_lapply(
     dataset_paths_second_half, 
@@ -354,11 +175,10 @@ weekly_results_second_half <-
   bind_rows()
 tictoc::toc()
 
-# Combine the sliding window weekly results from both halves
 weekly_results <- bind_rows(weekly_results_first_half, weekly_results_second_half)
 
-# Run the first half of the datasets in parallel for sliding window weekly SRI
-tictoc::tic("Sliding window weekly SRI calculation for first half")
+# Weekly sliding window timescale summarization
+tictoc::tic()
 weekly_sliding_results_first_half <- 
   future_lapply(
     dataset_paths_first_half, 
@@ -369,8 +189,7 @@ weekly_sliding_results_first_half <-
   bind_rows()
 tictoc::toc()
 
-# Run the second half of the datasets in parallel for sliding window weekly SRI
-tictoc::tic("Sliding window weekly SRI calculation for second half")
+tictoc::tic()
 weekly_sliding_results_second_half <- 
   future_lapply(
     dataset_paths_second_half, 
@@ -381,18 +200,16 @@ weekly_sliding_results_second_half <-
   bind_rows()
 tictoc::toc()
 
-# Combine the sliding window weekly results from both halves
 weekly_sliding_results <- bind_rows(weekly_results_first_half, weekly_results_second_half)
 
-
-# Weekly statistics
+# Weekly timescale results
 weekly_stats <- 
   list(
     weekly = weekly_results,
     sliding = weekly_sliding_results
   )
 
-# All-time statistics
+# All-time timescale results
 alltime_stats <-
   list(
     alltime = final_results,
@@ -451,4 +268,3 @@ syn_temp$login()
 
 synutils <- reticulate::import("synapseutils")
 synutils$syncToSynapse(syn = syn_temp, manifestFile = manifest_path)
-

--- a/scripts/sri.R
+++ b/scripts/sri.R
@@ -150,7 +150,8 @@ calc_sri_parallel <- function(dataset_path, post_infection = FALSE) {
     unnest(cols = c(DateTime))
   
   # Merge the full sequence with the original data and fill missing SleepStatus values with NA
-  complete_df <- full_intervals %>%
+  complete_df <- 
+    full_intervals %>%
     left_join(participant_df, by = "DateTime") %>% 
     mutate(SleepStatus = replace_na(SleepStatus, NA)) %>% 
     mutate(SleepStatus = ifelse(is.na(id) & is.na(SleepStatus), 0, SleepStatus))
@@ -185,6 +186,30 @@ tictoc::toc()
 # Combine the results
 final_results <- bind_rows(results_first_half, results_second_half)
 
+# All-time 3 months post-infection results
+results_first_half_post_infection_3 <- 
+  future_lapply(dataset_paths_first_half, calc_sri_parallel, months(3)) %>% 
+  bind_rows()
+
+results_second_half_post_infection_3 <- 
+  future_lapply(dataset_paths_second_half, calc_sri_parallel, months(3)) %>% 
+  bind_rows()
+
+final_results_post_infection_3 <- 
+  bind_rows(results_first_half_post_infection_3, results_second_half_post_infection_3)
+
+# All-time 6 months post-infection results
+results_first_half_post_infection_6 <- 
+  future_lapply(dataset_paths_first_half, calc_sri_parallel, months(6)) %>% 
+  bind_rows()
+
+results_second_half_post_infection_6 <- 
+  future_lapply(dataset_paths_second_half, calc_sri_parallel, months(6)) %>% 
+  bind_rows()
+
+final_results_post_infection_6 <- 
+  bind_rows(results_first_half_post_infection_6, results_second_half_post_infection_6)
+
 # Weekly statistics
 weekly_stats <- 
   list(
@@ -196,7 +221,7 @@ weekly_stats <-
 alltime_stats <-
   list(
     alltime = final_results,
-    start3monthspostinfection = NULL,
-    start6monthspostinfection = NULL
+    start3monthspostinfection = final_results_post_infection_3,
+    start6monthspostinfection = final_results_post_infection_6
   )
 

--- a/scripts/sri.R
+++ b/scripts/sri.R
@@ -4,7 +4,7 @@ source("scripts/functions/sri.R")
 library(future.apply)
 
 # Set the number of cores for parallel processing to 75% of available cores
-num_cores <- parallel::detectCores()*0.75
+num_cores <- floor(parallel::detectCores()*0.75)
 plan(multisession, workers = num_cores)
 
 # Load and filter infections data from the provided CSV file

--- a/scripts/timeInSleepStages.R
+++ b/scripts/timeInSleepStages.R
@@ -97,7 +97,8 @@ thisScriptUrl <- "https://github.com/Sage-Bionetworks/recover-sleep-measures/blo
 
 manifest <-
   manifest %>%
-  mutate(executed = thisScriptUrl)
+  mutate(executed = thisScriptUrl, 
+         used = parquetDirId)
 
 write_tsv(manifest, manifest_path)
 

--- a/scripts/timeInSleepStages.R
+++ b/scripts/timeInSleepStages.R
@@ -72,3 +72,38 @@ alltime_stats <-
     .groups = "drop"
   ) %>% 
   ungroup()
+
+write_csv(
+  x = weekly_stats, 
+  file = file.path(outputDataDirTimeInSleepStages, "weekly_stats.csv")
+)
+
+write_csv(
+  x = alltime_stats, 
+  file = file.path(outputDataDirTimeInSleepStages, "alltime_stats.csv")
+)
+
+manifest_path <- file.path(outputDataDirTimeInSleepStages, "output-data-manifest.tsv")
+
+synapserutils::generate_sync_manifest(
+  directory_path = outputDataDirTimeInSleepStages,
+  parent_id = timeInSleepStagesSynDirId,
+  manifest_path = manifest_path
+)
+
+manifest <- read_tsv(manifest_path)
+
+thisScriptUrl <- "https://github.com/Sage-Bionetworks/recover-sleep-measures/blob/main/scripts/timeInSleepStages.R"
+
+manifest <-
+  manifest %>%
+  mutate(executed = thisScriptUrl)
+
+write_tsv(manifest, manifest_path)
+
+synclient <- reticulate::import("synapseclient")
+syn_temp <- synclient$Synapse()
+syn_temp$login()
+
+synutils <- reticulate::import("synapseutils")
+synutils$syncToSynapse(syn = syn_temp, manifestFile = manifest_path)


### PR DESCRIPTION
Reference: [RMHDR-263](https://sagebionetworks.jira.com/browse/RMHDR-263)

## Major Changes

1. Add functionality to summarize data on a three week sliding window timescale (step by one week)
2. Create new sleep measure SRI (Sleep Regularity Index)
3. Use updated logic for post-infection date timescale
4. Add new config params for paths to write output to and Synapse IDs to store output files in
5. Create manifest of output files and bulk upload to synapse


[RMHDR-263]: https://sagebionetworks.jira.com/browse/RMHDR-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ